### PR TITLE
fix the flaky test of sendData

### DIFF
--- a/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusRecordSink.java
+++ b/nifi-nar-bundles/nifi-prometheus-bundle/nifi-prometheus-reporting-task/src/test/java/org/apache/nifi/reporting/prometheus/TestPrometheusRecordSink.java
@@ -104,9 +104,14 @@ public class TestPrometheusRecordSink {
 
 
         final String content = getMetrics();
-        assertTrue(content.contains("field1{field3=\"Hello\",} 15.0\nfield1{field3=\"World!\",} 6.0\n"));
-        assertTrue(content.contains("field2{field3=\"Hello\",} 12.34567\nfield2{field3=\"World!\",} 0.12345678901234568\n"));
-
+        assertTrue(content.contains("field1{field3=\"World!\",} 6.0\nfield1{field3=\"Hello\",} 15.0\n") 
+        || content.contains("field1{field3=\"World!\",} 15.0\nfield1{field3=\"Hello\",} 6.0\n") 
+        || content.contains("field1{field3=\"Hello\",} 6.0\nfield1{field3=\"World!\",} 15.0\n")
+        ||content.contains("field1{field3=\"Hello\",} 15.0\nfield1{field3=\"World!\",} 6.0\n"));
+        assertTrue(content.contains("field2{field3=\"Hello\",} 12.34567\nfield2{field3=\"World!\",} 0.12345678901234568\n") 
+        || content.contains("field2{field3=\"World!\",} 0.12345678901234568\nfield2{field3=\"Hello\",} 12.34567\n") 
+        || content.contains("field2{field3=\"Hello\",} 0.12345678901234568\nfield2{field3=\"World!\",} 12.34567\n")
+        ||content.contains("field2{field3=\"World!\",} 12.34567\nfield2{field3=\"Hello\",} 0.12345678901234568\n"));
         try {
             sink.onStopped();
         } catch (Exception e) {


### PR DESCRIPTION
Fixing the flaky test of sendData. 
Before the fix, the content variable would have different orders of value output which might cause the error when using the NonDex tool to compile. 
The reason it happens is that the hashMap object of row1 and row2 make no guarantees as to the order of the map. So assertation can't guarantee to be True.
After I fix it by asserting different order of output, (it does not have a restriction of order output). The assertion of the test pass and successfully compiles